### PR TITLE
feat: More robust handling of calendar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 build:
 	- go build -o bin/nepcal .
 
+run:
+	- make build
+	- ./bin/nepcal
+
 test:
 	- go test -v ./...

--- a/calendar.go
+++ b/calendar.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/nepcal/nepcal/internal/conversion"
+)
+
+// val keeps track of where we are when printing the calendar.
+var val = 1
+
+// renderCalendar prints the BS calendar for the given time.Time.
+// For printing formatted/aligned output, we use a tabwriter from the
+// standard library. It doesn't support ANSI escapes so we cant have
+// color/other enhancements to the output.(https://github.com/nepcal/nepcal/issues/4)
+func renderCalendar(parentWriter io.Writer, t time.Time) {
+	w := tabwriter.NewWriter(parentWriter, 0, 0, 1, ' ', 0)
+	ad := toEpoch(t)
+	bs := conversion.ToBS(ad)
+
+	renderBSDateHeader(w, bs)
+	renderStaticDaysHeader(w)
+	renderFirstRow(w, ad, bs)
+	renderCalWithoutFirstRow(w, ad, bs)
+
+	w.Flush()
+}
+
+// renderFirstRow renders the first row of the calendar. The reason this needs
+// to be handled separately is because there is a skew in each month which
+// determines which day the month starts from - we need to tab space the 'skew' number
+// of days, then start printing from the day after the skew.
+func renderFirstRow(w io.Writer, ad, bs conversion.Epoch) {
+	offset := calculateSkew(ad, bs)
+	for i := 0; i < offset; i++ {
+		fmt.Fprintf(w, "\t")
+	}
+
+	for i := 0; i < (7 - offset); i++ {
+		fmt.Fprintf(w, "\t%d", val)
+		val++
+	}
+
+	fmt.Fprint(w, "\n")
+}
+
+// renderCalWithoutFirstRow renders the rest of the calendar without the first row.
+// renderFirstRow will handle that due to special circumstances. We basically loop over
+// each row and print 7 numbers until we are at the end of the month.
+func renderCalWithoutFirstRow(w io.Writer, ad, bs conversion.Epoch) {
+	daysInMonth := conversion.BsDaysInMonthsByYear[bs.Year][bs.Month-1]
+
+	for val < daysInMonth {
+		start := daysInMonth - val
+		end := start + 7
+
+		for i := start; i < end; i++ {
+			if val > daysInMonth {
+				break
+			}
+
+			fmt.Fprintf(w, "\t%d", val)
+			val++
+		}
+
+		fmt.Fprint(w, "\n")
+	}
+}
+
+// renderStaticDaysHeader prints the static list of days for the calendar
+func renderStaticDaysHeader(w io.Writer) {
+	for _, v := range []string{"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"} {
+		fmt.Fprintf(w, "%s\t", v)
+	}
+
+	fmt.Fprint(w, "\n")
+}
+
+// renderBSDateHeader prints the date corresponding to the epoch.
+func renderBSDateHeader(w io.Writer, e conversion.Epoch) {
+	fmt.Fprintf(w, "\t\t%s %d, %d\n\t", conversion.BSMonths[e.Month], e.Day, e.Year)
+}
+
+// calculateSkew calculates the offset at the beginning of the month. Given an AD and
+// BS date, we calculate the diff in days from the BS date to the start of the month in BS.
+// We subtract that from the AD date, and get the weekday.
+// For example, a skew of 2 means the month starts from Tuesday.
+func calculateSkew(ad, bs conversion.Epoch) int {
+	adDate := fromEpoch(ad)
+	dayDiff := (bs.Day % 7) - 1
+	adWithoutbsDiffDays := adDate.AddDate(0, 0, -dayDiff)
+	d := adWithoutbsDiffDays.Weekday()
+
+	// Since time.Weekday is an iota and not an iota + 1 we can avoid
+	// subtracting 1 from the return value.
+	return int(d)
+}
+
+// fromEpoch creates a time.Time type from an Epoch
+func fromEpoch(e conversion.Epoch) time.Time {
+	return time.Date(e.Year, time.Month(e.Month), e.Day, 0, 0, 0, 0, time.UTC)
+}
+
+// toEpoch creates a conversion.Epoch from a time.Time
+func toEpoch(t time.Time) conversion.Epoch {
+	yy, mm, dd := t.Date()
+
+	return conversion.Epoch{
+		Year:  yy,
+		Month: int(mm),
+		Day:   dd,
+	}
+}

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nepcal/nepcal/internal/conversion"
+	"github.com/stretchr/testify/assert"
+)
+
+var fixtures = map[string]time.Time{
+	"May17":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
+	"May19":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
+	"May26":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
+	"June15": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
+}
+
+// Test the 'calculateSkew' function.
+func TestCalculateSkew(t *testing.T) {
+	tests := []struct {
+		name     string
+		adDate   conversion.Epoch
+		bsDate   conversion.Epoch
+		expected int
+	}{
+		{
+			"less than 7",
+			toEpoch(fixtures["May17"]),
+			conversion.ToBS(toEpoch(fixtures["May17"])),
+			2,
+		},
+		{
+			"less than 7",
+			toEpoch(fixtures["May19"]),
+			conversion.ToBS(toEpoch(fixtures["May19"])),
+			2,
+		},
+		{
+			"less than 7",
+			toEpoch(fixtures["June15"]),
+			conversion.ToBS(toEpoch(fixtures["June15"])),
+			5,
+		},
+		{
+			"more than 7",
+			toEpoch(fixtures["May26"]),
+			conversion.ToBS(toEpoch(fixtures["May26"])),
+			2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, calculateSkew(test.adDate, test.bsDate))
+		})
+	}
+}
+
+// Test the 'renderCalendar' function
+func TestRenderCalendar(t *testing.T) {
+	tests := []struct {
+		name     string
+		t        time.Time
+		expected string
+	}{
+		{
+			"May",
+			fixtures["May17"],
+			`
+			जेठ 3, 2075
+ Su Mo Tu We Th Fr Sa 
+       1  2  3  4  5
+ 6  7  8  9  10 11 12
+ 13 14 15 16 17 18 19
+ 20 21 22 23 24 25 26
+ 27 28 29 30 31
+		`,
+		},
+	}
+
+	clean := func(op string) string {
+		woNewLines := strings.Trim(op, "\n")
+		woSpaces := strings.TrimSpace(woNewLines)
+
+		return woSpaces
+	}
+
+	for _, test := range tests {
+		b := bytes.NewBuffer([]byte("k ho"))
+
+		t.Run(test.name, func(t *testing.T) {
+			b.Reset()
+			renderCalendar(b, test.t)
+			assert.Equal(t, clean(test.expected), clean(b.String()))
+		})
+	}
+}

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -88,7 +88,7 @@ func TestRenderCalendar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b := bytes.NewBuffer([]byte("k ho"))
+		b := bytes.NewBuffer([]byte(""))
 
 		t.Run(test.name, func(t *testing.T) {
 			b.Reset()

--- a/main.go
+++ b/main.go
@@ -1,26 +1,28 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
-	"text/tabwriter"
 	"time"
 
 	"github.com/nepcal/nepcal/internal/conversion"
 )
 
-// Cheap testing.
-var (
-	stdout io.Writer = os.Stdout
-)
-
 func main() {
-	showCal(time.Now())
+	dateFlag := flag.Bool("d", false, "Print only the date")
+	flag.Parse()
+
+	if *dateFlag {
+		showDate(os.Stdout, time.Now())
+	} else {
+		renderCalendar(os.Stdout, time.Now())
+	}
 }
 
 // showDate prints the current B.S. date
-func showDate(t time.Time) {
+func showDate(w io.Writer, t time.Time) {
 	yy, mm, dd := t.Date()
 
 	bs := conversion.ToBS(
@@ -31,64 +33,5 @@ func showDate(t time.Time) {
 		},
 	)
 
-	fmt.Fprintf(stdout, "%s %d, %d\n", conversion.BSMonths[bs.Month], bs.Day, bs.Year)
-}
-
-// showCal prints the current calendar.
-func showCal(t time.Time) {
-	yy, mm, dd := t.Date()
-	w := tabwriter.NewWriter(stdout, 0, 0, 1, ' ', 0)
-
-	bs := conversion.ToBS(
-		conversion.Epoch{
-			Year:  yy,
-			Month: int(mm),
-			Day:   dd,
-		},
-	)
-
-	// Month header
-	fmt.Fprintf(w, "\t\t%s %d, %d\n\t", conversion.BSMonths[bs.Month], bs.Day, bs.Year)
-
-	// Days list
-	printDay := func(day string) {
-		fmt.Fprintf(w, "%s\t", day)
-	}
-	for _, v := range []string{"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"} {
-		printDay(v)
-	}
-	fmt.Fprint(w, "\n")
-
-	// Calendar
-	printVal := func(v int) {
-		fmt.Fprintf(w, "\t%d", v)
-	}
-
-	daysInMonth := conversion.BsDaysInMonthsByYear[bs.Year][bs.Month]
-	offset := dd % 7
-	val := 1
-	for i := 0; i < offset-1; i++ {
-		fmt.Fprintf(w, "\t")
-	}
-	for i := 0; i <= offset+1; i++ {
-		printVal(val)
-		val++
-	}
-	fmt.Fprint(w, "\n")
-
-	for val < daysInMonth {
-		start := daysInMonth - val
-		end := start + 7
-
-		for i := start; i < end; i++ {
-			if val > daysInMonth {
-				break
-			}
-
-			printVal(val)
-			val++
-		}
-		fmt.Fprint(w, "\n")
-	}
-	w.Flush()
+	fmt.Fprintf(w, "%s %d, %d\n", conversion.BSMonths[bs.Month], bs.Day, bs.Year)
 }

--- a/main.go
+++ b/main.go
@@ -10,14 +10,28 @@ import (
 	"github.com/nepcal/nepcal/internal/conversion"
 )
 
-func main() {
-	dateFlag := flag.Bool("d", false, "Print only the date")
-	flag.Parse()
+// Cheap testing.
+var writer io.Writer = os.Stdout
 
-	if *dateFlag {
-		showDate(os.Stdout, time.Now())
+// Flag list
+var (
+	dateFlag = flag.Bool("d", false, "Print only the date")
+)
+
+func init() {
+	flag.Parse()
+}
+
+func main() {
+	render(*dateFlag)
+}
+
+// Render decides what to show based on the flags.
+func render(dateFlag bool) {
+	if dateFlag {
+		showDate(writer, time.Now())
 	} else {
-		renderCalendar(os.Stdout, time.Now())
+		renderCalendar(writer, time.Now())
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRender(t *testing.T) {
+	dateBuf := bytes.NewBuffer([]byte(""))
+	calBuf := bytes.NewBuffer([]byte(""))
+
+	writer = dateBuf
+	render(true)
+
+	writer = calBuf
+	render(false)
+
+	if len(dateBuf.String()) > len(calBuf.String()) {
+		t.Fatalf("Expected dateBuf to have a lower length than calBuf")
+	}
+}
+
 func TestShowDate(t *testing.T) {
 	b := bytes.NewBuffer([]byte(""))
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -12,10 +10,6 @@ import (
 
 func TestShowDate(t *testing.T) {
 	b := bytes.NewBuffer([]byte(""))
-	stdout = b
-	defer func() {
-		stdout = os.Stdout
-	}()
 
 	tests := []struct {
 		name     string
@@ -31,50 +25,8 @@ func TestShowDate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			showDate(test.t)
+			showDate(b, test.t)
 			assert.Equal(t, test.expected, b.String())
-		})
-	}
-}
-
-func TestShowCal(t *testing.T) {
-	b := bytes.NewBuffer([]byte(""))
-	stdout = b
-	defer func() {
-		stdout = os.Stdout
-	}()
-
-	tests := []struct {
-		name     string
-		t        time.Time
-		expected string
-	}{
-		{
-			"case-1",
-			time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
-			`
-			जेठ 3, 2075
- Su Mo Tu We Th Fr Sa 
-       1  2  3  4  5
- 6  7  8  9  10 11 12
- 13 14 15 16 17 18 19
- 20 21 22 23 24 25 26
- 27 28 29 30 31 32
-		`,
-		},
-	}
-
-	clean := func(op string) string {
-		woNewLines := strings.Trim(op, "\n")
-		woSpaces := strings.TrimSpace(woNewLines)
-
-		return woSpaces
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			showCal(test.t)
-			assert.Equal(t, clean(test.expected), clean(b.String()))
 		})
 	}
 }


### PR DESCRIPTION
Less hacky code than what was previously being done I suppose.

Bug fixes:
* Fixed calendar overflowing from the row for certain months
* Fixed calendar not showing the correct number of days in the month
* Fixed offset logic incorrectly calculating the skew

Improvements:
* Added a new `calendar.go` file to handle calendar tasks.
* Moved tests around accordingly.

Features:
* Added a new `-d` flag to only show the date, not the whole calendar.